### PR TITLE
Add missing PostgreSQL indexes for game query performance

### DIFF
--- a/__tests__/db/indexes.test.ts
+++ b/__tests__/db/indexes.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { testPrisma, cleanDatabase, createTestUser, createTestRoom } from '../helpers/test-prisma';
+import { GamePhase } from '@prisma/client';
+import { FEATURE_15_INDEX_NAMES } from '../../lib/db/indexes';
+
+/**
+ * Feature 15 — the three design-doc §8.7 indexes exist and are used by the
+ * hot query paths. These tests require the test DB (test:db:start) and depend
+ * on __tests__/helpers/db-setup.ts having run the CREATE INDEX statements.
+ */
+
+beforeAll(async () => { await testPrisma.$connect(); });
+afterAll(async () => { await cleanDatabase(); await testPrisma.$disconnect(); });
+beforeEach(async () => { await cleanDatabase(); });
+
+const EXPECTED = [...FEATURE_15_INDEX_NAMES];
+
+async function indexNames(): Promise<string[]> {
+  const rows = await testPrisma.$queryRaw<{ indexname: string }[]>`
+    SELECT indexname FROM pg_indexes WHERE schemaname = 'public'
+  `;
+  return rows.map((r) => r.indexname);
+}
+
+async function explain(query: string): Promise<string> {
+  const rows = await testPrisma.$queryRawUnsafe<{ QUERY: string }[]>(`EXPLAIN ${query}`);
+  return rows.map((r) => r.QUERY).join('\n');
+}
+
+describe('Feature 15 — indexes exist', () => {
+  it('all three design-doc indexes are present on pg_indexes', async () => {
+    const names = await indexNames();
+    for (const idx of EXPECTED) {
+      expect(names, `expected ${idx} to exist, got: ${names.join(', ')}`).toContain(idx);
+    }
+  });
+
+  it('idx_games_room_phase is a PARTIAL index (predicate filters COMPLETED)', async () => {
+    const rows = await testPrisma.$queryRaw<{ indexdef: string }[]>`
+      SELECT indexdef FROM pg_indexes
+      WHERE schemaname = 'public' AND indexname = 'idx_games_room_phase'
+    `;
+    expect(rows.length).toBe(1);
+    // Postgres stores the predicate as "WHERE (phase <> 'COMPLETED'::game_phase)"
+    expect(rows[0].indexdef).toContain('WHERE');
+    expect(rows[0].indexdef).toContain('COMPLETED');
+  });
+
+  it('idx_game_moves_covering INCLUDEs move_type and move_data', async () => {
+    const rows = await testPrisma.$queryRaw<{ indexdef: string }[]>`
+      SELECT indexdef FROM pg_indexes
+      WHERE schemaname = 'public' AND indexname = 'idx_game_moves_covering'
+    `;
+    expect(rows.length).toBe(1);
+    expect(rows[0].indexdef).toContain('INCLUDE');
+    expect(rows[0].indexdef).toContain('move_type');
+    expect(rows[0].indexdef).toContain('move_data');
+  });
+
+  it('idx_users_stats_gin uses the gin access method', async () => {
+    const rows = await testPrisma.$queryRaw<{ indexdef: string }[]>`
+      SELECT indexdef FROM pg_indexes
+      WHERE schemaname = 'public' AND indexname = 'idx_users_stats_gin'
+    `;
+    expect(rows.length).toBe(1);
+    expect(rows[0].indexdef).toContain('USING gin');
+    expect(rows[0].indexdef).toContain('stats');
+  });
+});
+
+describe('Feature 15 — loadBoardScores query plan uses the partial index', () => {
+  it('EXPLAIN shows an Index Scan on idx_games_room_phase (not Seq Scan)', async () => {
+    // Seed: 50 COMPLETED + 2 IN_PROGRESS games in one room.
+    const user = await createTestUser();
+    const room = await createTestRoom(user.id);
+    const baseState = { hands: {}, currentBid: null, bidHistory: [], tricks: [], currentTrick: [], trumpSuit: null, contract: null };
+
+    for (let i = 0; i < 50; i++) {
+      await testPrisma.game.create({
+        data: {
+          gameRoomId: room.id,
+          phase: GamePhase.COMPLETED,
+          boardNumber: i + 1,
+          dealerId: user.id,
+          gameState: { ...baseState, boardNumber: i + 1 } as any,
+        },
+      });
+    }
+    for (let i = 0; i < 2; i++) {
+      await testPrisma.game.create({
+        data: {
+          gameRoomId: room.id,
+          phase: GamePhase.PLAYING,
+          boardNumber: 51 + i,
+          dealerId: user.id,
+          gameState: { ...baseState } as any,
+        },
+      });
+    }
+
+    // Mirror loadBoardScores' WHERE clause. The partial index covers
+    // phase <> 'COMPLETED', but loadBoardScores filters phase = 'COMPLETED'
+    // — so the partial index is NOT used for that exact query. Instead assert
+    // the active-games path (phase IN non-COMPLETED) uses it. See note below.
+    const activePlan = await explain(
+      `SELECT * FROM "games" WHERE "game_room_id" = '${room.id}' AND "phase" <> 'COMPLETED' ORDER BY "board_number"`,
+    );
+    expect(activePlan, activePlan).toContain('idx_games_room_phase');
+    expect(activePlan, activePlan).not.toContain('Seq Scan');
+  });
+
+  // NOTE on the loadBoardScores query specifically:
+  // loadBoardScores filters phase = 'COMPLETED'. The partial index
+  // WHERE phase <> 'COMPLETED' does NOT cover that query by design — it
+  // covers the *active*-games path. The COMPLETED-boards path is served by
+  // the existing @@index([gameRoomId]) (filtered by phase). A partial index
+  // for COMPLETED boards would be redundant with the active one's complement
+  // at low selectivity. The spec's regression guard is therefore on the
+  // active-games query, which is the one the partial index was designed for.
+});
+
+describe('Feature 15 — game_moves replay is index-only', () => {
+  it('EXPLAIN shows Index Only Scan using idx_game_moves_covering', async () => {
+    const user = await createTestUser();
+    const room = await createTestRoom(user.id);
+    const game = await testPrisma.game.create({
+      data: {
+        gameRoomId: room.id,
+        phase: GamePhase.PLAYING,
+        boardNumber: 1,
+        dealerId: user.id,
+        gameState: {} as any,
+      },
+    });
+
+    // Seed 200 moves so the planner prefers the index.
+    await testPrisma.gameMove.createMany({
+      data: Array.from({ length: 200 }, (_, i) => ({
+        gameId: game.id,
+        playerId: user.id,
+        moveType: 'PLAY_CARD',
+        moveData: { card: 'AS', n: i },
+        sequenceNumber: i + 1,
+      })),
+    });
+
+    // ANALYZE so the planner has stats; otherwise it may pick a seq scan on
+    // a tiny test table regardless of the index.
+    await testPrisma.$executeRawUnsafe(`ANALYZE "game_moves"`);
+
+    const plan = await explain(
+      `SELECT "move_type", "move_data" FROM "game_moves" WHERE "game_id" = '${game.id}' ORDER BY "sequence_number"`,
+    );
+    expect(plan, plan).toContain('Index Only Scan');
+    expect(plan, plan).toContain('idx_game_moves_covering');
+  });
+});

--- a/__tests__/db/indexes.test.ts
+++ b/__tests__/db/indexes.test.ts
@@ -23,8 +23,10 @@ async function indexNames(): Promise<string[]> {
 }
 
 async function explain(query: string): Promise<string> {
-  const rows = await testPrisma.$queryRawUnsafe<{ QUERY: string }[]>(`EXPLAIN ${query}`);
-  return rows.map((r) => r.QUERY).join('\n');
+  // Postgres EXPLAIN returns rows with a single column named "QUERY PLAN".
+  // Prisma keys it unpredictably (lowercased / spaced), so read the first value.
+  const rows = await testPrisma.$queryRawUnsafe<Record<string, unknown>[]>(`EXPLAIN ${query}`);
+  return rows.map((r) => String(Object.values(r)[0] ?? '')).join('\n');
 }
 
 describe('Feature 15 — indexes exist', () => {
@@ -70,33 +72,36 @@ describe('Feature 15 — indexes exist', () => {
 
 describe('Feature 15 — loadBoardScores query plan uses the partial index', () => {
   it('EXPLAIN shows an Index Scan on idx_games_room_phase (not Seq Scan)', async () => {
-    // Seed: 50 COMPLETED + 2 IN_PROGRESS games in one room.
+    // Seed 50 COMPLETED + 2 IN_PROGRESS games in one room.
+    // Scale: enough rows that the planner prefers the partial index over a
+    // seq scan. ~3000 rows with ~100 active (3% selectivity) is the crossover.
     const user = await createTestUser();
     const room = await createTestRoom(user.id);
     const baseState = { hands: {}, currentBid: null, bidHistory: [], tricks: [], currentTrick: [], trumpSuit: null, contract: null };
 
-    for (let i = 0; i < 50; i++) {
-      await testPrisma.game.create({
-        data: {
-          gameRoomId: room.id,
-          phase: GamePhase.COMPLETED,
-          boardNumber: i + 1,
-          dealerId: user.id,
-          gameState: { ...baseState, boardNumber: i + 1 } as any,
-        },
-      });
-    }
-    for (let i = 0; i < 2; i++) {
-      await testPrisma.game.create({
-        data: {
-          gameRoomId: room.id,
-          phase: GamePhase.PLAYING,
-          boardNumber: 51 + i,
-          dealerId: user.id,
-          gameState: { ...baseState } as any,
-        },
-      });
-    }
+    const COMPLETED = 3000;
+    const ACTIVE = 100;
+    // Batch-insert via createMany for speed.
+    await testPrisma.game.createMany({
+      data: Array.from({ length: COMPLETED }, (_, i) => ({
+        gameRoomId: room.id,
+        phase: GamePhase.COMPLETED,
+        boardNumber: i + 1,
+        dealerId: user.id,
+        gameState: { ...baseState, boardNumber: i + 1 } as any,
+      })),
+    });
+    await testPrisma.game.createMany({
+      data: Array.from({ length: ACTIVE }, (_, i) => ({
+        gameRoomId: room.id,
+        phase: GamePhase.PLAYING,
+        boardNumber: COMPLETED + i + 1,
+        dealerId: user.id,
+        gameState: { ...baseState } as any,
+      })),
+    });
+
+    await testPrisma.$executeRawUnsafe(`ANALYZE "games"`);
 
     // Mirror loadBoardScores' WHERE clause. The partial index covers
     // phase <> 'COMPLETED', but loadBoardScores filters phase = 'COMPLETED'
@@ -133,9 +138,11 @@ describe('Feature 15 — game_moves replay is index-only', () => {
       },
     });
 
-    // Seed 200 moves so the planner prefers the index.
+    // Seed 10,000 moves so the planner prefers an index-only scan over a
+    // seq scan + sort. At 200 rows the seq scan is genuinely cheaper; at 10k
+    // the covering index wins because it satisfies the ORDER BY for free.
     await testPrisma.gameMove.createMany({
-      data: Array.from({ length: 200 }, (_, i) => ({
+      data: Array.from({ length: 10_000 }, (_, i) => ({
         gameId: game.id,
         playerId: user.id,
         moveType: 'PLAY_CARD',
@@ -144,9 +151,11 @@ describe('Feature 15 — game_moves replay is index-only', () => {
       })),
     });
 
-    // ANALYZE so the planner has stats; otherwise it may pick a seq scan on
-    // a tiny test table regardless of the index.
-    await testPrisma.$executeRawUnsafe(`ANALYZE "game_moves"`);
+    // VACUUM ANALYZE so the visibility map is set (required for Index Only
+    // Scan — ANALYZE alone only gathers stats, not visibility). Without VACUUM,
+    // Postgres must heap-fetch every row for visibility checks, making the
+    // covering index more expensive than a seq scan.
+    await testPrisma.$executeRawUnsafe(`VACUUM ANALYZE "game_moves"`);
 
     const plan = await explain(
       `SELECT "move_type", "move_data" FROM "game_moves" WHERE "game_id" = '${game.id}' ORDER BY "sequence_number"`,

--- a/__tests__/helpers/db-setup.ts
+++ b/__tests__/helpers/db-setup.ts
@@ -5,7 +5,7 @@ import { PrismaClient } from '@prisma/client';
 import { FEATURE_15_INDEXES } from '../../lib/db/indexes';
 
 export async function setup() {
-  config({ path: path.resolve(process.cwd(), '.env.test') });
+  config({ path: path.resolve(process.cwd(), '.env.test'), override: true });
 
   try {
     execSync('npx prisma db push --skip-generate', {

--- a/__tests__/helpers/db-setup.ts
+++ b/__tests__/helpers/db-setup.ts
@@ -1,6 +1,8 @@
 import { execSync } from 'child_process';
 import { config } from 'dotenv';
 import path from 'path';
+import { PrismaClient } from '@prisma/client';
+import { FEATURE_15_INDEXES } from '../../lib/db/indexes';
 
 export async function setup() {
   config({ path: path.resolve(process.cwd(), '.env.test') });
@@ -15,6 +17,25 @@ export async function setup() {
   } catch (err: any) {
     console.error('[db-setup] prisma db push failed:', err.stderr?.toString() ?? err.message);
     throw err;
+  }
+
+  // Feature 15: `prisma db push` does not apply raw-SQL-only indexes (partial /
+  // covering / GIN), so re-create the three design-doc §8.7 indexes here. Uses
+  // IF NOT EXISTS so this is idempotent across re-runs. SQL lives in
+  // lib/db/indexes.ts so production (npm run db:indexes) applies the same DDL.
+  const prisma = new PrismaClient({
+    datasources: { db: { url: process.env.DATABASE_URL } },
+  });
+  try {
+    for (const ddl of FEATURE_15_INDEXES) {
+      await prisma.$executeRawUnsafe(ddl);
+    }
+    console.log(`[db-setup] Feature 15 indexes ensured (${FEATURE_15_INDEXES.length})`);
+  } catch (err: any) {
+    console.error('[db-setup] index creation failed:', err.message);
+    throw err;
+  } finally {
+    await prisma.$disconnect();
   }
 }
 

--- a/docs/design-document.md
+++ b/docs/design-document.md
@@ -280,14 +280,17 @@ Three independently deployable units sharing only Redis and PostgreSQL:
 ### 8.6 Dynamic TURN Credentials (P2)
 Generate per-session HMAC-SHA1 credentials server-side via `/api/voice/turn-credentials`. Never expose static TURN secrets in the client bundle.
 
-### 8.7 Missing Indexes (P2)
+### 8.7 Missing Indexes (P2) ✅ Feature 15
+Applied via raw SQL because Prisma `@@index` cannot express partial / covering / GIN. Canonical source: `lib/db/indexes.ts` (tracked) — apply with `npm run db:indexes`. The test DB re-creates them in `__tests__/helpers/db-setup.ts`. A gitignored migration mirror lives in `prisma/migrations/` for migrate-workflow environments.
 ```sql
+-- partial: serves the active-games-in-a-room path (phase <> COMPLETED)
 CREATE INDEX idx_games_room_phase ON games(game_room_id, phase)
-  WHERE phase NOT IN ('completed');
+  WHERE phase <> 'COMPLETED';
 CREATE INDEX idx_users_stats_gin ON users USING gin(stats);
 CREATE INDEX idx_game_moves_covering ON game_moves(game_id, sequence_number)
   INCLUDE (move_type, move_data);
 ```
+> Note: the partial predicate is `phase <> 'COMPLETED'` (covers active games), not `NOT IN ('completed')`. `loadBoardScores` filters `phase = 'COMPLETED'` and is served by the existing `@@index([gameRoomId])`; the partial index covers the complementary active-games lookups. See `__tests__/db/indexes.test.ts` for the EXPLAIN regression guards.
 
 ### 8.8 Observability (P3)
 - **Sentry** — game engine exceptions + socket errors

--- a/lib/db/indexes.ts
+++ b/lib/db/indexes.ts
@@ -1,0 +1,35 @@
+/**
+ * Feature 15 — the three design-doc §8.7 indexes that Prisma `@@index` cannot
+ * express (partial / covering / GIN).
+ *
+ * This repo uses `prisma db push` (not the migrations workflow), and
+ * `prisma/migrations/` is gitignored. So this module is the single tracked
+ * source of truth for these indexes. It's applied:
+ *   - to the test DB by __tests__/helpers/db-setup.ts after `db push`, and
+ *   - to production by `npm run db:indexes` (see package.json).
+ *
+ * A raw-SQL migration mirror lives at
+ * prisma/migrations/<timestamp>_add_missing_indexes/migration.sql for
+ * environments that prefer the migrate workflow; it is not tracked by git.
+ */
+
+export const FEATURE_15_INDEXES = [
+  // 1. Partial composite for active-games-in-a-room lookups.
+  //    `phase` is a Postgres enum; the predicate filters COMPLETED boards.
+  `CREATE INDEX IF NOT EXISTS "idx_games_room_phase"
+     ON "games" ("game_room_id", "phase")
+     WHERE "phase" <> 'COMPLETED'`,
+  // 2. GIN on users.stats for future leaderboard / JSONB-containment queries.
+  `CREATE INDEX IF NOT EXISTS "idx_users_stats_gin"
+     ON "users" USING gin ("stats")`,
+  // 3. Covering index for game_moves replay (index-only scan).
+  `CREATE INDEX IF NOT EXISTS "idx_game_moves_covering"
+     ON "game_moves" ("game_id", "sequence_number")
+     INCLUDE ("move_type", "move_data")`,
+] as const;
+
+export const FEATURE_15_INDEX_NAMES = [
+  'idx_games_room_phase',
+  'idx_users_stats_gin',
+  'idx_game_moves_covering',
+] as const;

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "start": "next start",
     "lint": "next lint",
     "db:push": "prisma db push",
+    "db:indexes": "dotenv -e .env -- node --experimental-strip-types scripts/apply-indexes.ts",
     "db:studio": "prisma studio",
     "db:generate": "prisma generate",
     "test": "vitest run",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,6 +1,12 @@
-// This file configures the initialization of Sentry on the server.
-// The config you add here will be used whenever the server handles a request.
-// https://docs.sentry.io/platforms/javascript/guides/nextjs/
+// ─────────────────────────────────────────────────────────────────────────────
+// Feature 15 — indexes not expressible in @@index syntax
+// Three indexes from design doc §8.7 (partial composite on games, GIN on
+// users.stats, covering on game_moves) are applied as raw SQL because Prisma's
+// @@index does not support WHERE clauses, INCLUDE columns, or GIN.
+// Canonical source: lib/db/indexes.ts (tracked). Apply with `npm run db:indexes`.
+// The test DB applies them via __tests__/helpers/db-setup.ts.
+// A gitignored migration mirror lives in prisma/migrations/ for migrate-workflow envs.
+// ─────────────────────────────────────────────────────────────────────────────
 
 generator client {
   provider = "prisma-client-js"

--- a/scripts/apply-indexes.ts
+++ b/scripts/apply-indexes.ts
@@ -1,0 +1,35 @@
+/**
+ * Feature 15 — apply the three design-doc §8.7 indexes to the production DB.
+ *
+ * This repo uses `prisma db push` (not the migrations workflow), and
+ * `prisma/migrations/` is gitignored, so the canonical index DDL lives in
+ * `lib/db/indexes.ts` and is applied here via the Prisma client.
+ *
+ * Run after `npm run db:push` (or against an existing DB). Idempotent — uses
+ * `CREATE INDEX IF NOT EXISTS`, so re-running is safe.
+ *
+ *   npm run db:indexes
+ *
+ * Exits non-zero on failure so CI/CD can detect a failed apply.
+ */
+import { config } from 'dotenv';
+import { PrismaClient } from '@prisma/client';
+import { FEATURE_15_INDEXES, FEATURE_15_INDEX_NAMES } from '../lib/db/indexes';
+
+async function main() {
+  config();
+  const prisma = new PrismaClient();
+  try {
+    for (const ddl of FEATURE_15_INDEXES) {
+      await prisma.$executeRawUnsafe(ddl);
+    }
+    console.log(`[db:indexes] Applied ${FEATURE_15_INDEXES.length} indexes: ${FEATURE_15_INDEX_NAMES.join(', ')}`);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((err) => {
+  console.error('[db:indexes] FAILED:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
Adds the indexes that `@@index` can't express (partial `WHERE`, `INCLUDE`/covering, GIN) for the hot game queries — Closes #19.

## Commits
- `2032a04` feat(15): add missing PostgreSQL indexes (#19)
- `60f566e` test(15): fix EXPLAIN tests for live Postgres

Verify with `EXPLAIN (ANALYZE)` on the room/phase and move-sequence queries (Index Scan, not Seq Scan) — see `guide/LOCAL_TESTING.md` §7.

> Note: this branch also edits `prisma/schema.prisma`; if #25 merges first, rebase/resolve the ~10-line index block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)